### PR TITLE
[Feat] 내 서재 뷰 구현

### DIFF
--- a/BookKitty/BookKitty.xcodeproj/project.pbxproj
+++ b/BookKitty/BookKitty.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		606DA2422D4206F200C7FAA3 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 606DA2412D4206F200C7FAA3 /* RxSwift */; };
 		606DA2452D42076100C7FAA3 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 606DA2442D42076100C7FAA3 /* Then */; };
 		606DA2482D42079900C7FAA3 /* Differentiator in Frameworks */ = {isa = PBXBuildFile; productRef = 606DA2472D42079900C7FAA3 /* Differentiator */; };
+		60A1CC0E2D54A2DB00091568 /* BookRecommendationKit in Frameworks */ = {isa = PBXBuildFile; productRef = 60A1CC0D2D54A2DB00091568 /* BookRecommendationKit */; };
 		60F1CE8C2D53715B00E3F881 /* BookMatchKit in Frameworks */ = {isa = PBXBuildFile; productRef = 60F1CE8B2D53715B00E3F881 /* BookMatchKit */; };
 		E5FC698C2D52414B002875FD /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = E5FC698B2D52414B002875FD /* SnapKit */; };
 		E97DC3702D50C161009ADFEA /* DesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = E97DC36F2D50C161009ADFEA /* DesignSystem */; };
@@ -75,6 +76,7 @@
 				E5FC698C2D52414B002875FD /* SnapKit in Frameworks */,
 				606DA2402D4206F200C7FAA3 /* RxRelay in Frameworks */,
 				E97DC3702D50C161009ADFEA /* DesignSystem in Frameworks */,
+				60A1CC0E2D54A2DB00091568 /* BookRecommendationKit in Frameworks */,
 				606DA2422D4206F200C7FAA3 /* RxSwift in Frameworks */,
 				6041EB682D507E2800061ED0 /* RxDataSources in Frameworks */,
 				606DA2482D42079900C7FAA3 /* Differentiator in Frameworks */,
@@ -149,6 +151,7 @@
 				E9A9DF5A2D51EB54002EF385 /* RxCocoa */,
 				E5FC698B2D52414B002875FD /* SnapKit */,
 				60F1CE8B2D53715B00E3F881 /* BookMatchKit */,
+				60A1CC0D2D54A2DB00091568 /* BookRecommendationKit */,
 			);
 			productName = BookKitty;
 			productReference = 60551C652D40E6E800CFC16A /* BookKitty.app */;
@@ -617,6 +620,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 606DA2462D42079900C7FAA3 /* XCRemoteSwiftPackageReference "RxDataSources" */;
 			productName = Differentiator;
+		};
+		60A1CC0D2D54A2DB00091568 /* BookRecommendationKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BookRecommendationKit;
 		};
 		60F1CE8B2D53715B00E3F881 /* BookMatchKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/BookKitty/BookKitty/BookMatchKit/Package.swift
+++ b/BookKitty/BookKitty/BookMatchKit/Package.swift
@@ -70,6 +70,6 @@ let package = Package(
                 "RxSwift", "SwiftFormat",
                 "BookMatchKit", "BookRecommendationKit", "BookMatchCore",
             ]
-        )
+        ),
     ]
 )

--- a/BookKitty/BookKitty/BookMatchKit/Sources/BookMatchCore/Protocols/BookRecommendable.swift
+++ b/BookKitty/BookKitty/BookMatchKit/Sources/BookMatchCore/Protocols/BookRecommendable.swift
@@ -3,5 +3,6 @@ import UIKit
 
 public protocol BookRecommendable {
     func recommendBooks(from ownedBooks: [OwnedBook]) async -> [BookItem]
-    func recommendBooks(for question: String, from ownedBooks: [OwnedBook]) async -> BookMatchModuleOutput
+    func recommendBooks(for question: String, from ownedBooks: [OwnedBook]) async
+        -> BookMatchModuleOutput
 }

--- a/BookKitty/BookKitty/BookMatchKit/Sources/BookRecommendationKit/BookRecommendationKit.swift
+++ b/BookKitty/BookKitty/BookMatchKit/Sources/BookRecommendationKit/BookRecommendationKit.swift
@@ -83,7 +83,10 @@ public final class BookRecommendationKit: BookRecommendable {
     ///   - input: 사용자의 질문과 보유 도서 정보를 포함한 입력 데이터
     /// - Returns: 추천된 도서 목록과 설명을 포함한 출력 데이터
     /// - Throws: BookMatchError.questionShort (질문이 4글자 미만인 경우)
-    public func recommendBooks(for question: String, from ownedBooks: [OwnedBook]) async -> BookMatchModuleOutput {
+    public func recommendBooks(
+        for question: String,
+        from ownedBooks: [OwnedBook]
+    ) async -> BookMatchModuleOutput {
         do {
             let startTime = Date().timeIntervalSince1970
             guard question.count >= 4 else {

--- a/BookKitty/BookKitty/BookMatchKit/Tests/BookMatchKitTests/BookMatchKitTests.swift
+++ b/BookKitty/BookKitty/BookMatchKit/Tests/BookMatchKitTests/BookMatchKitTests.swift
@@ -1,4 +1,4 @@
-//@testable import BookMatchCore
+// @testable import BookMatchCore
 @testable import BookMatchKit
 @testable import BookRecommendationKit
 import XCTest
@@ -36,32 +36,32 @@ final class BookMatchKitTests: XCTestCase {
             naverClientSecret: "",
             openAIApiKey: ""
         )
-        
+
         //        for id in 0 ..< 5 {
         for question in questions {
-            
             let result = await module.recommendBooks(for: question, from: [])
             total += result.newBooks.count
-            
+
             XCTAssertTrue(!result.description.isEmpty)
             XCTAssertTrue(!result.newBooks.isEmpty)
-            
+
             //                for book in result.newBooks {
-            //                    let myBool = await accurancyTester(question: question, title: book.title)
+            //                    let myBool = await accurancyTester(question: question, title:
+            //                    book.title)
             //                    if myBool == 1 {
             //                        cnt += 1
             //                    }
             //                }
-            
+
             print(result)
         }
         let acc = Double(cnt) / Double(total)
         XCTAssertTrue(acc > 0.9)
 //        print("accurancy in \(id + 1)th try: \(acc)")
-        
+
         results.append(acc)
         //        }
-        
+
         print("total accurancy: \(results.reduce(0.0,+) / 5.0)")
     }
 

--- a/BookKitty/BookKitty/Source/Common/Model/Book.swift
+++ b/BookKitty/BookKitty/Source/Common/Model/Book.swift
@@ -6,12 +6,17 @@
 //
 
 import Foundation
+import RxDataSources
 
-struct Book: Hashable {
+struct Book: IdentifiableType, Hashable {
     let isbn: String
     let title: String
     let author: String
     let publisher: String
     let thumbnailUrl: URL?
     var isOwned = false
+
+    var identity: String {
+        isbn
+    }
 }

--- a/BookKitty/BookKitty/Source/Common/Model/SectionOfBook.swift
+++ b/BookKitty/BookKitty/Source/Common/Model/SectionOfBook.swift
@@ -11,8 +11,17 @@ struct SectionOfBook {
     var items: [Item]
 }
 
-extension SectionOfBook: SectionModelType {
+enum SectionType: Hashable {
+    case main
+}
+
+extension SectionOfBook: AnimatableSectionModelType {
+    typealias Identity = SectionType
     typealias Item = Book
+
+    var identity: SectionType {
+        .main
+    }
 
     init(original: SectionOfBook, items: [Book]) {
         self = original

--- a/BookKitty/BookKitty/Source/Common/Service/Mock/MockRecommendationService.swift
+++ b/BookKitty/BookKitty/Source/Common/Service/Mock/MockRecommendationService.swift
@@ -7,10 +7,11 @@
 
 import BookMatchCore
 import Foundation
+import RxSwift
 import UIKit
 
 /// Mock 추천 서비스 클래스
-class MockRecommendationService: BookMatchable {
+class MockRecommendationService: BookRecommendable {
     let mockBookData = [
         BookItem(
             id: "12313",
@@ -97,15 +98,7 @@ class MockRecommendationService: BookMatchable {
         ),
     ]
 
-    func recommendBooks(from _: [BookMatchCore.OwnedBook]) async -> [BookMatchCore.BookItem] {
-        []
-    }
-
-    func matchBook(_: [[String]], image _: UIImage) async -> BookMatchCore.BookItem? {
-        nil
-    }
-
-    func recommendBooks(for _: BookMatchCore.BookMatchModuleInput) async -> BookMatchCore
+    func recommendBooks(for _: String, from _: [BookMatchCore.OwnedBook]) async -> BookMatchCore
         .BookMatchModuleOutput {
         BookMatchModuleOutput(
             ownedISBNs: [
@@ -115,5 +108,19 @@ class MockRecommendationService: BookMatchable {
             newBooks: mockBookData,
             description: "이러한 이유로 당신에게 책을 추천합니당"
         )
+    }
+
+    func matchBook(_: [[String]], image _: UIImage) -> RxSwift.Single<BookMatchCore.BookItem?> {
+        Single.create { _ in
+            Disposables.create {}
+        }
+    }
+
+    func recommendBooks(from _: [BookMatchCore.OwnedBook]) async -> [BookMatchCore.BookItem] {
+        []
+    }
+
+    func matchBook(_: [[String]], image _: UIImage) async -> BookMatchCore.BookItem? {
+        nil
     }
 }

--- a/BookKitty/BookKitty/Source/Coordinator/AddQuestionCoordinator.swift
+++ b/BookKitty/BookKitty/Source/Coordinator/AddQuestionCoordinator.swift
@@ -7,6 +7,7 @@
 
 import BookMatchAPI
 import BookMatchKit
+import BookRecommendationKit
 import RxCocoa
 import RxSwift
 import UIKit
@@ -63,14 +64,10 @@ extension AddQuestionCoordinator {
     /// - Parameter question: 사용자가 입력한 질문 내용
     private func showQuestionResultScene(with question: String) {
         // TODO: xcconfig 활용, API 키 집어넣기
-        let recommendationService = BookMatchModule(
-            apiClient: DefaultAPIClient(
-                configuration: .init(
-                    naverClientId: "",
-                    naverClientSecret: "",
-                    openAIApiKey: ""
-                )
-            )
+        let recommendationService = BookRecommendationKit(
+            naverClientId: "",
+            naverClientSecret: "",
+            openAIApiKey: ""
         )
         // TODO: Mock 레포지토리들 Real로 변경
         let repository = MockBookRepository()
@@ -90,7 +87,6 @@ extension AddQuestionCoordinator {
         questionResultViewModel.navigateToBookDetail
             .withUnretained(self)
             .bind(onNext: { owner, book in
-                // TODO: book을 넘겨주는 방식으로 변경
                 owner.showBookDetailScene(with: book.isbn)
             }).disposed(by: disposeBag)
 

--- a/BookKitty/BookKitty/Source/Feature/MyLibrary/View/MyLibraryCollectionViewCell.swift
+++ b/BookKitty/BookKitty/Source/Feature/MyLibrary/View/MyLibraryCollectionViewCell.swift
@@ -1,0 +1,92 @@
+//
+//  MyLibraryCollectionViewCell.swift
+//  BookKitty
+//
+//  Created by 권승용 on 2/6/25.
+//
+
+import DesignSystem
+import SnapKit
+import UIKit
+
+final class MyLibraryCollectionViewCell: UICollectionViewCell {
+    // MARK: Lifecycle
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureHierarchy()
+        configureLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: Internal
+
+    static let reuseIdentifier = "MyLibraryCollectionViewCell"
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        // 기존 요청 취소 및 기본 이미지 설정
+        imageLoadTask?.cancel()
+        cellImageView.image = nil
+        currentImageUrl = nil
+    }
+
+    // TODO: 고도화 필요
+    func configureCell(imageUrl: URL?) {
+        // 기존 요청이 있다면 취소
+        imageLoadTask?.cancel()
+        currentImageUrl = imageUrl
+
+        guard let imageUrl else {
+            cellImageView.image = UIImage(systemName: "photo")
+            return
+        }
+
+        let request = URLRequest(
+            url: imageUrl,
+            cachePolicy: .returnCacheDataElseLoad,
+            timeoutInterval: 10
+        )
+        imageLoadTask = URLSession.shared.dataTask(with: request) { [weak self] data, _, error in
+            guard let self, let data, error == nil, let image = UIImage(data: data) else {
+                DispatchQueue.main.async {
+                    if self?.currentImageUrl == imageUrl {
+                        self?.cellImageView.image = UIImage(systemName: "photo")
+                    }
+                }
+                return
+            }
+
+            DispatchQueue.main.async {
+                if self.currentImageUrl == imageUrl {
+                    self.cellImageView.image = image
+                }
+            }
+        }
+        imageLoadTask?.resume()
+    }
+
+    // MARK: Private
+
+    private var imageLoadTask: URLSessionDataTask?
+    private var currentImageUrl: URL?
+
+    private let cellImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFit
+        $0.isUserInteractionEnabled = true
+    }
+
+    private func configureHierarchy() {
+        contentView.addSubview(cellImageView)
+    }
+
+    private func configureLayout() {
+        cellImageView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+}

--- a/BookKitty/BookKitty/Source/Feature/MyLibrary/View/MyLibraryViewController.swift
+++ b/BookKitty/BookKitty/Source/Feature/MyLibrary/View/MyLibraryViewController.swift
@@ -6,9 +6,12 @@
 //  Created by 전성규 on 1/27/25.
 //
 
+import DesignSystem
 import RxCocoa
+import RxDataSources
 import RxSwift
 import SnapKit
+import Then
 import UIKit
 
 final class MyLibraryViewController: BaseViewController {
@@ -29,58 +32,126 @@ final class MyLibraryViewController: BaseViewController {
     override func bind() {
         let input = MyLibraryViewModel.Input(
             viewDidLoad: viewDidLoadRelay.asObservable(),
-            // TODO: 컬렉션뷰 셀 탭 시 탭 된 셀의 Book 정보 방출하는 relay에 연결
-            bookTapped: Observable<Book>.create { _ in
-                Disposables.create()
-            },
-            // TODO: 컬렉션뷰 하단 스크롤 이벤트 연결
-            reachedScrollEnd: Observable<Void>.create { _ in
-                Disposables.create()
-            }
+            bookTapped: bookTappedRelay.asObservable(),
+            reachedScrollEnd: reachedScrollEndRelay.asObservable()
         )
 
         let output = viewModel.transform(input)
 
         output.bookList
-            .drive { books in
-                print(books)
+            .drive(myLibraryCollectionView.rx.items(dataSource: dataSource))
+            .disposed(by: disposeBag)
+
+        myLibraryCollectionView.rx.itemSelected
+            .withLatestFrom(output.bookList) { indexPath, sectionOfBooks in
+                let books = sectionOfBooks[0].items
+                return books[indexPath.item]
             }
+            .bind(to: bookTappedRelay)
             .disposed(by: disposeBag)
     }
 
     override func configureHierarchy() {
-        [testLabel, testButton].forEach { view.addSubview($0) }
+        [
+            myLibraryHeadlineLabel,
+            myLibraryCollectionView,
+        ].forEach { view.addSubview($0) }
     }
 
     override func configureLayout() {
-        testLabel.snp.makeConstraints { $0.center.equalToSuperview() }
+        myLibraryHeadlineLabel.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(Vars.spacing20)
+            make.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(Vars.spacing24)
+        }
 
-        testButton.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.top.equalTo(testLabel.snp.bottom).offset(20.0)
-            $0.width.height.equalTo(150.0)
+        myLibraryCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(myLibraryHeadlineLabel.snp.bottom).offset(Vars.spacing20)
+            make.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
         }
     }
 
     // MARK: Private
 
+    private let bookTappedRelay = PublishRelay<Book>()
+    private let reachedScrollEndRelay = PublishRelay<Void>()
+
     private let viewModel: MyLibraryViewModel
 
-    private let testLabel: UILabel = {
-        let label = UILabel()
-        label.text = "P-003"
-        label.font = .systemFont(ofSize: 30.0, weight: .bold)
+    private let myLibraryHeadlineLabel = Headline1Label(weight: .extraBold).then {
+        $0.text = "나의 책장"
+    }
 
-        return label
-    }()
+    private lazy var myLibraryCollectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: makeCompositionalLayout()
+    ).then {
+        $0.delegate = self
+        $0.register(
+            MyLibraryCollectionViewCell.self,
+            forCellWithReuseIdentifier: MyLibraryCollectionViewCell.reuseIdentifier
+        )
+    }
 
-    private let testButton: UIButton = {
-        let button = UIButton()
-        button.setTitle("Book Thumbnail", for: .normal)
-        button.backgroundColor = .tintColor
+    private let dataSource = RxCollectionViewSectionedAnimatedDataSource<SectionOfBook>(
+        configureCell: { _, collectionView, indexPath, item in
+            guard let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: MyLibraryCollectionViewCell.reuseIdentifier,
+                for: indexPath
+            ) as? MyLibraryCollectionViewCell else {
+                return MyLibraryCollectionViewCell()
+            }
 
-        return button
-    }()
+            cell.configureCell(imageUrl: item.thumbnailUrl)
+
+            return cell
+        }
+    )
+}
+
+extension MyLibraryViewController {
+    func makeCompositionalLayout() -> UICollectionViewCompositionalLayout {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(0.3),
+            heightDimension: .fractionalHeight(1)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .absolute(150)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            repeatingSubitem: item,
+            count: 3
+        )
+        group.interItemSpacing = .flexible(Vars.spacing4)
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: Vars.spacing20,
+            leading: Vars.spacing24,
+            bottom: 0,
+            trailing: Vars.spacing24
+        )
+        section.interGroupSpacing = Vars.spacing32
+
+        return UICollectionViewCompositionalLayout(section: section)
+    }
+}
+
+// TODO: 고도화 필요
+extension MyLibraryViewController: UICollectionViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard scrollView.contentSize.height > scrollView.bounds.height else {
+            return
+        }
+
+        if scrollView.contentOffset.y > scrollView.contentSize.height - scrollView.bounds.height {
+            reachedScrollEndRelay.accept(())
+        }
+    }
 }
 
 @available(iOS 17.0, *)

--- a/BookKitty/BookKitty/Source/Feature/MyLibrary/ViewModel/MyLibraryViewModel.swift
+++ b/BookKitty/BookKitty/Source/Feature/MyLibrary/ViewModel/MyLibraryViewModel.swift
@@ -35,7 +35,7 @@ final class MyLibraryViewModel: ViewModelType {
     /// ViewModel이 View에게 전달할 출력 데이터들을 정의
     struct Output {
         /// 화면에 표시될 책 목록
-        let bookList: Driver<[Book]>
+        let bookList: Driver<[SectionOfBook]>
     }
 
     let disposeBag = DisposeBag()
@@ -56,10 +56,12 @@ final class MyLibraryViewModel: ViewModelType {
         input.viewDidLoad
             .withUnretained(self)
             .map { _ in
-                self.bookRepository.fetchBookList(
+                let fetchedBooks = self.bookRepository.fetchBookList(
                     offset: self.offset,
                     limit: self.limit
                 )
+                self.books = fetchedBooks
+                return [SectionOfBook(items: self.books)]
             }
             .bind(to: bookList)
             .disposed(by: disposeBag)
@@ -69,7 +71,7 @@ final class MyLibraryViewModel: ViewModelType {
             .withUnretained(self)
             .map { _ in
                 guard !self.isLoading else {
-                    return self.books
+                    return [SectionOfBook(items: self.books)]
                 }
                 self.isLoading = true
                 self.offset += self.limit
@@ -77,8 +79,9 @@ final class MyLibraryViewModel: ViewModelType {
                     offset: self.offset,
                     limit: self.limit
                 )
+                self.books += fetchedBooks
                 self.isLoading = false
-                return fetchedBooks
+                return [SectionOfBook(items: self.books)]
             }
             .bind(to: bookList)
             .disposed(by: disposeBag)
@@ -90,7 +93,7 @@ final class MyLibraryViewModel: ViewModelType {
 
     // MARK: Private
 
-    private let bookList = BehaviorRelay<[Book]>(value: [])
+    private let bookList = BehaviorRelay<[SectionOfBook]>(value: [])
 
     private var offset = 0
     private let limit = 15

--- a/BookKitty/BookKitty/Source/Feature/QuestionHistory/View/QuestionHistoryCell.swift
+++ b/BookKitty/BookKitty/Source/Feature/QuestionHistory/View/QuestionHistoryCell.swift
@@ -33,12 +33,12 @@ final class QuestionHistoryCell: UITableViewCell {
 
     static let identifier = "QuestionHistoryCell"
 
-    func configure(with question: Question) {
-        let isOverlapNeeded = question.recommandedBooks.count > 3
+    func configure(with questionAnswer: QuestionAnswer) {
+        let isOverlapNeeded = questionAnswer.recommendedBooks.count > 3
 
-        dateLabel.text = DateFormatter.shared.string(from: question.createdAt)
-        questionLabel.text = question.userQuestion
-        answerLabel.text = question.gptAnswer
+        dateLabel.text = DateFormatter.shared.string(from: questionAnswer.createdAt)
+        questionLabel.text = questionAnswer.userQuestion
+        answerLabel.text = questionAnswer.gptAnswer
 
         recommendedBooksStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
 
@@ -46,7 +46,7 @@ final class QuestionHistoryCell: UITableViewCell {
             recommendedBooksStackView.spacing = -48
         }
 
-        for book in question.recommandedBooks {
+        for book in questionAnswer.recommendedBooks {
             let imageView = HeightFixedImageView(
                 imageUrl: book.thumbnailUrl?.absoluteString ?? "",
                 height: .regular

--- a/BookKitty/BookKitty/Source/Feature/QuestionHistory/View/QuestionHistoryViewController.swift
+++ b/BookKitty/BookKitty/Source/Feature/QuestionHistory/View/QuestionHistoryViewController.swift
@@ -31,7 +31,8 @@ final class QuestionHistoryViewController: BaseViewController {
     override func bind() {
         let input = QuestionHistoryViewModel.Input(
             viewDidLoad: viewDidLoadRelay.asObservable(),
-            questionSelected: questionTableView.rx.modelSelected(Question.self).asObservable(),
+            questionSelected: questionTableView.rx.modelSelected(QuestionAnswer.self)
+                .asObservable(),
             reachedScrollEnd: questionTableView.rx.reachedBottom()
         )
 
@@ -121,7 +122,7 @@ extension Reactive where Base: UIScrollView {
 #Preview {
     QuestionHistoryViewController(
         viewModel: QuestionHistoryViewModel(
-            questionRepository: MockQuestionHistoryRepository()
+            questionHistoryRepository: MockQuestionHistoryRepository()
         )
     )
 }

--- a/BookKitty/BookKitty/Source/Feature/QuestionResult/ViewModel/QuestionResultViewModel.swift
+++ b/BookKitty/BookKitty/Source/Feature/QuestionResult/ViewModel/QuestionResultViewModel.swift
@@ -6,7 +6,7 @@
 //
 
 import BookMatchCore
-import BookMatchKit
+import BookRecommendationKit
 import Foundation
 import RxCocoa
 import RxSwift
@@ -16,7 +16,7 @@ final class QuestionResultViewModel: ViewModelType {
 
     init(
         userQuestion: String,
-        recommendationService: BookMatchable,
+        recommendationService: BookRecommendable,
         bookRepository: BookRepository,
         questionHistoryRepository: QuestionHistoryRepository
     ) {
@@ -90,7 +90,7 @@ final class QuestionResultViewModel: ViewModelType {
 
     private let questionHistoryRepository: QuestionHistoryRepository
     private let bookRepository: BookRepository
-    private let recommendationService: BookMatchable
+    private let recommendationService: BookRecommendable
 
     private let userQuestionRelay = BehaviorRelay<String>(value: "")
     private let recommendedBooksRelay = BehaviorRelay<[SectionOfBook]>(value: [])
@@ -111,22 +111,15 @@ final class QuestionResultViewModel: ViewModelType {
                     )
                 }
 
-                // 서비스 입력을 위한 데이터 생성
-                let input = BookMatchModuleInput(
-                    question: self.userQuestion,
-                    ownedBooks: ownedBooks
-                )
-
                 // 추천 서비스 호출
                 return Observable<(String, BookMatchModuleOutput)>.create { observer in
                     let task = Task {
-                        do {
-                            // TODO: 에러 받아서 처리하기
-                            let output = await self.recommendationService.recommendBooks(for: input)
-                            observer.onNext((self.userQuestion, output)) // 결과 방출
-                        } catch {
-                            self.errorRelay.accept(error) // 에러 발생 시 처리
-                        }
+                        // TODO: 에러 받아서 처리하기
+                        let output = await self.recommendationService.recommendBooks(
+                            for: self.userQuestion,
+                            from: ownedBooks
+                        )
+                        observer.onNext((self.userQuestion, output)) // 결과 방출
                     }
                     return Disposables.create {
                         task.cancel() // 작업 취소

--- a/BookKitty/BookKitty/Source/Repository/MockBookRepository.swift
+++ b/BookKitty/BookKitty/Source/Repository/MockBookRepository.swift
@@ -11,65 +11,90 @@ import Foundation
 final class MockBookRepository: BookRepository {
     let mockBookList = [
         Book(
-            isbn: "978-3-16-148410-0",
-            title: "Swift Programming Basics",
-            author: "John Doe",
-            publisher: "Tech Press",
-            thumbnailUrl: URL(string: "https://picsum.photos/200/300")
+            isbn: "9788950963262",
+            title: "침묵의 기술",
+            author: "조제프 앙투안 투생 디누아르",
+            publisher: "아르테(arte)",
+            thumbnailUrl: URL(
+                string: "https://shopping-phinf.pstatic.net/main_3249696/32496966995.20240321071044.jpg"
+            )
         ),
         Book(
-            isbn: "978-1-23-456789-7",
-            title: "Mastering iOS Development",
-            author: "Jane Smith",
-            publisher: "Code Masters",
-            thumbnailUrl: URL(string: "https://picsum.photos/200/300")
+            isbn: "9788954625760",
+            title: "불안의 책",
+            author: "페르난두 페소아",
+            publisher: "문학동네",
+            thumbnailUrl: URL(
+                string: "https://shopping-phinf.pstatic.net/main_3245596/32455964233.20230822103854.jpg"
+            )
         ),
         Book(
-            isbn: "978-0-12-345678-9",
-            title: "The Art of Clean Code",
-            author: "Robert C. Martin",
-            publisher: "Pragmatic Bookshelf",
-            thumbnailUrl: URL(string: "https://picsum.photos/200/300")
+            isbn: "9788981171353",
+            title: "마음챙김 명상",
+            author: "존 카밧진",
+            publisher: "사람과책",
+            thumbnailUrl: URL(
+                string: "https://shopping-phinf.pstatic.net/main_3245593/32455931661.20220527022757.jpg"
+            )
         ),
         Book(
-            isbn: "978-9-87-654321-0",
-            title: "Data Structures & Algorithms",
-            author: "Alice Johnson",
-            publisher: "Algo Press",
-            thumbnailUrl: URL(string: "https://picsum.photos/200/300")
+            isbn: "9791196914806",
+            title: "당신 인생의 이야기",
+            author: "테드 창",
+            publisher: "엘리",
+            thumbnailUrl: URL(
+                string: "https://shopping-phinf.pstatic.net/main_3248052/32480522779.20231230070743.jpg"
+            )
         ),
     ]
 
     let mockBookDetail = Book(
-        isbn: "978-9-87-654321-0",
-        title: "Data Structures & Algorithms",
-        author: "Alice Johnson",
-        publisher: "Algo Press",
-        thumbnailUrl: URL(string: "https://picsum.photos/200/300")
+        isbn: "9788950963262",
+        title: "침묵의 기술",
+        author: "조제프 앙투안 투생 디누아르",
+        publisher: "아르테(arte)",
+        thumbnailUrl: URL(
+            string: "https://shopping-phinf.pstatic.net/main_3249696/32496966995.20240321071044.jpg"
+        )
     )
 
     func fetchAllBooks() -> [Book] {
         [
             Book(
-                isbn: "978-3-16-148410-0",
-                title: "Swift Programming Basics",
-                author: "John Doe",
-                publisher: "Tech Press",
-                thumbnailUrl: URL(string: "https://picsum.photos/200/300")
+                isbn: "9788950963262",
+                title: "침묵의 기술",
+                author: "조제프 앙투안 투생 디누아르",
+                publisher: "아르테(arte)",
+                thumbnailUrl: URL(
+                    string: "https://shopping-phinf.pstatic.net/main_3249696/32496966995.20240321071044.jpg"
+                )
             ),
             Book(
-                isbn: "978-3-16-148410-0",
-                title: "Swift Programming Basics",
-                author: "John Doe",
-                publisher: "Tech Press",
-                thumbnailUrl: URL(string: "https://picsum.photos/200/300")
+                isbn: "9788954625760",
+                title: "불안의 책",
+                author: "페르난두 페소아",
+                publisher: "문학동네",
+                thumbnailUrl: URL(
+                    string: "https://shopping-phinf.pstatic.net/main_3245596/32455964233.20230822103854.jpg"
+                )
             ),
             Book(
-                isbn: "978-3-16-148410-0",
-                title: "Swift Programming Basics",
-                author: "John Doe",
-                publisher: "Tech Press",
-                thumbnailUrl: URL(string: "https://picsum.photos/200/300")
+                isbn: "9788981171353",
+                title: "마음챙김 명상",
+                author: "존 카밧진",
+                publisher: "사람과책",
+                thumbnailUrl: URL(
+                    string: "https://shopping-phinf.pstatic.net/main_3245593/32455931661.20220527022757.jpg"
+                )
+            ),
+            Book(
+                isbn: "9791196914806",
+                title: "당신 인생의 이야기",
+                author: "테드 창",
+                publisher: "엘리",
+                thumbnailUrl: URL(
+                    string: "https://shopping-phinf.pstatic.net/main_3248052/32480522779.20231230070743.jpg"
+                )
             ),
         ]
     }

--- a/BookKitty/BookKittyTests/ViewModelTests/MyLibraryViewModelTests.swift
+++ b/BookKitty/BookKittyTests/ViewModelTests/MyLibraryViewModelTests.swift
@@ -31,7 +31,7 @@ struct MyLibraryViewModelTests {
         let output = vm.transform(input)
         // 책 목록이 방출될 때까지 기다림
         for await value in output.bookList.values {
-            #expect(value == repository.mockBookList) // 방출된 값이 예상한 책 목록과 같은지 확인
+            #expect(value[0].items == repository.mockBookList) // 방출된 값이 예상한 책 목록과 같은지 확인
             break
         }
     }
@@ -85,7 +85,7 @@ struct MyLibraryViewModelTests {
         // 책 목록이 방출될 때까지 기다림
         // BehaviorRelay로 동작하기 때문에 값 곧바로 얻음
         for await value in output.bookList.values {
-            #expect(value == repository.mockBookList) // 방출된 값이 예상한 책 목록과 같은지 확인
+            #expect(value[0].items == repository.mockBookList) // 방출된 값이 예상한 책 목록과 같은지 확인
             break
         }
     }


### PR DESCRIPTION
## ✅ 작업 사항
- 내 서재 뷰 구현
- 뷰모델과의 연동 구현

## 👉 리뷰 포인트
### 이미지 고도화 필요
- 디자인시스템 컴포넌트를 사용하지 못했습니다,,,
- 제 한계로 일단 셀 너비에 맞춘 이미지뷰로 구현했습니다
- 추후 고도화가 필요합니다.

### 무한스크롤 고도화 필요
- 지금은 스크롤 끝에 닿으면 곧바로 추가 정보가 로드되는데요, 좀 더 이쁜 방법이 필요해 보입니다.

### AnimatableDatasSource 유의
- 현재 RxDataSource의 AnimatableDataSource 사용하기 때문에, 데이터 모델에 서로 같은 값이 존재한다면 앱 크래시가 발생합니다.
- 이 부분 유의해야 합니다.  

## 📸 스크린샷

| 스크린샷 |
| -- |
|<img src="https://github.com/user-attachments/assets/85603e7d-9936-4058-a16f-a309dbe089e0" width=300>|
