### PR TITLE
[Feat] BookDetail 화면 바인딩

### DIFF
--- a/BookKitty/BookKitty/DesignSystem/Sources/DesignSystem/Source/Component/UIView/ManageBookPopupView.swift
+++ b/BookKitty/BookKitty/DesignSystem/Sources/DesignSystem/Source/Component/UIView/ManageBookPopupView.swift
@@ -93,12 +93,12 @@ extension ManageBookPopupView {
         switch mode {
         case .add:
             messageLabel.text = "나의 책장에 아래의 책을 등록하시겠습니까?"
-            iconImageView.image = UIImage(systemName: "trash.fill")
-            iconImageView.tintColor = Colors.statusRed
-        case .delete:
-            messageLabel.text = "나의 책장에서 아래의 책을 제외하시겠습니까?"
             iconImageView.image = UIImage(systemName: "bookmark.fill")
             iconImageView.tintColor = Colors.brandMain
+        case .delete:
+            messageLabel.text = "나의 책장에서 아래의 책을 제외하시겠습니까?"
+            iconImageView.image = UIImage(systemName: "trash.fill")
+            iconImageView.tintColor = Colors.statusRed
         }
     }
 

--- a/BookKitty/BookKitty/Source/Coordinator/AddQuestionCoordinator.swift
+++ b/BookKitty/BookKitty/Source/Coordinator/AddQuestionCoordinator.swift
@@ -99,7 +99,11 @@ extension AddQuestionCoordinator {
     /// 책 상세 화면을 표시하는 메서드
     /// - Parameter isbn: 선택한 책의 ISBN 번호
     private func showBookDetailScene(with book: Book) {
-        let bookDetailViewModel = BookDetailViewModel(bookDetail: book)
+        let bookRepository = MockBookRepository()
+        let bookDetailViewModel = BookDetailViewModel(
+            bookDetail: book,
+            bookRepository: bookRepository
+        )
         let bookDetailViewController = BookDetailViewController(viewModel: bookDetailViewModel)
         bookDetailViewModel.navigateBackRelay
             .observe(on: MainScheduler.instance)

--- a/BookKitty/BookKitty/Source/Coordinator/AddQuestionCoordinator.swift
+++ b/BookKitty/BookKitty/Source/Coordinator/AddQuestionCoordinator.swift
@@ -82,7 +82,7 @@ extension AddQuestionCoordinator {
         questionResultViewModel.navigateToBookDetail
             .withUnretained(self)
             .bind(onNext: { owner, book in
-                owner.showBookDetailScene(with: book.isbn)
+                owner.showBookDetailScene(with: book)
             }).disposed(by: disposeBag)
         questionResultViewModel.navigateToQuestionHistory
             .withUnretained(self)
@@ -98,9 +98,8 @@ extension AddQuestionCoordinator {
 
     /// 책 상세 화면을 표시하는 메서드
     /// - Parameter isbn: 선택한 책의 ISBN 번호
-    private func showBookDetailScene(with isbn: String) {
-        let bookDetailViewModel = BookDetailViewModel()
-        bookDetailViewModel.isbnRelay.accept(isbn)
+    private func showBookDetailScene(with book: Book) {
+        let bookDetailViewModel = BookDetailViewModel(bookDetail: book)
         let bookDetailViewController = BookDetailViewController(viewModel: bookDetailViewModel)
         bookDetailViewModel.navigateBackRelay
             .observe(on: MainScheduler.instance)

--- a/BookKitty/BookKitty/Source/Coordinator/BookCoordinator.swift
+++ b/BookKitty/BookKitty/Source/Coordinator/BookCoordinator.swift
@@ -58,7 +58,11 @@ extension BookCoordinator {
     ///
     /// 책 상세 화면을 생성하고 ViewModel과 ViewController를 연결
     private func showBookDetailScreen(with book: Book) {
-        let bookDetailViewModel = BookDetailViewModel(bookDetail: book)
+        let bookRepository = MockBookRepository()
+        let bookDetailViewModel = BookDetailViewModel(
+            bookDetail: book,
+            bookRepository: bookRepository
+        )
         let bookDetailViewController = BookDetailViewController(viewModel: bookDetailViewModel)
         navigationController.pushViewController(bookDetailViewController, animated: true)
     }

--- a/BookKitty/BookKitty/Source/Coordinator/BookCoordinator.swift
+++ b/BookKitty/BookKitty/Source/Coordinator/BookCoordinator.swift
@@ -49,16 +49,16 @@ extension BookCoordinator {
         myLibraryViewModel
             .navigateToBookDetail
             .withUnretained(self)
-            .subscribe(onNext: { owner, _ in
-                owner.showBookDetailScreen()
+            .subscribe(onNext: { owner, book in
+                owner.showBookDetailScreen(with: book)
             }).disposed(by: disposeBag)
     }
 
     /// 책 상세 화면 표시
     ///
     /// 책 상세 화면을 생성하고 ViewModel과 ViewController를 연결
-    private func showBookDetailScreen() {
-        let bookDetailViewModel = BookDetailViewModel()
+    private func showBookDetailScreen(with book: Book) {
+        let bookDetailViewModel = BookDetailViewModel(bookDetail: book)
         let bookDetailViewController = BookDetailViewController(viewModel: bookDetailViewModel)
         navigationController.pushViewController(bookDetailViewController, animated: true)
     }

--- a/BookKitty/BookKitty/Source/Coordinator/HomeCoordinator.swift
+++ b/BookKitty/BookKitty/Source/Coordinator/HomeCoordinator.swift
@@ -70,8 +70,8 @@ extension DefaultHomeCoordinator {
     /// 책 상세 화면을 생성하고 ViewModel과 ViewController를 연결
     /// 탭바를 숨기고 화면을 네비게이션 스택에 추가
     /// - Parameter book: 책 상세 화면에서 표시할 Book 정보가 담긴 구조체
-    private func showBookDetailScreen(with _: Book) {
-        let bookDetailViewModel = BookDetailViewModel()
+    private func showBookDetailScreen(with book: Book) {
+        let bookDetailViewModel = BookDetailViewModel(bookDetail: book)
         let bookDetailViewController = BookDetailViewController(viewModel: bookDetailViewModel)
 
         navigationController.pushViewController(bookDetailViewController, animated: true)

--- a/BookKitty/BookKitty/Source/Coordinator/HomeCoordinator.swift
+++ b/BookKitty/BookKitty/Source/Coordinator/HomeCoordinator.swift
@@ -71,7 +71,11 @@ extension DefaultHomeCoordinator {
     /// 탭바를 숨기고 화면을 네비게이션 스택에 추가
     /// - Parameter book: 책 상세 화면에서 표시할 Book 정보가 담긴 구조체
     private func showBookDetailScreen(with book: Book) {
-        let bookDetailViewModel = BookDetailViewModel(bookDetail: book)
+        let bookRepository = MockBookRepository()
+        let bookDetailViewModel = BookDetailViewModel(
+            bookDetail: book,
+            bookRepository: bookRepository
+        )
         let bookDetailViewController = BookDetailViewController(viewModel: bookDetailViewModel)
 
         navigationController.pushViewController(bookDetailViewController, animated: true)

--- a/BookKitty/BookKitty/Source/Coordinator/MyLibraryCoordinator.swift
+++ b/BookKitty/BookKitty/Source/Coordinator/MyLibraryCoordinator.swift
@@ -61,8 +61,8 @@ extension MyLibraryCoordinator {
     /// 책 상세 화면을 생성하고 ViewModel과 ViewController를 연결
     /// 탭바를 숨기고 화면을 네비게이션 스택에 추가
     /// - Parameter book: 책 상세 화면에서 표시할 Book 정보가 담긴 구조체
-    private func showBookDetailScreen(with _: Book) {
-        let bookDetailViewModel = BookDetailViewModel()
+    private func showBookDetailScreen(with book: Book) {
+        let bookDetailViewModel = BookDetailViewModel(bookDetail: book)
         let bookDetailViewController = BookDetailViewController(viewModel: bookDetailViewModel)
         bookDetailViewModel.navigateBackRelay
             .observe(on: MainScheduler.instance)

--- a/BookKitty/BookKitty/Source/Coordinator/MyLibraryCoordinator.swift
+++ b/BookKitty/BookKitty/Source/Coordinator/MyLibraryCoordinator.swift
@@ -62,7 +62,11 @@ extension MyLibraryCoordinator {
     /// 탭바를 숨기고 화면을 네비게이션 스택에 추가
     /// - Parameter book: 책 상세 화면에서 표시할 Book 정보가 담긴 구조체
     private func showBookDetailScreen(with book: Book) {
-        let bookDetailViewModel = BookDetailViewModel(bookDetail: book)
+        let bookRepository = MockBookRepository()
+        let bookDetailViewModel = BookDetailViewModel(
+            bookDetail: book,
+            bookRepository: bookRepository
+        )
         let bookDetailViewController = BookDetailViewController(viewModel: bookDetailViewModel)
         bookDetailViewModel.navigateBackRelay
             .observe(on: MainScheduler.instance)

--- a/BookKitty/BookKitty/Source/Coordinator/QuestionCoordinator.swift
+++ b/BookKitty/BookKitty/Source/Coordinator/QuestionCoordinator.swift
@@ -77,7 +77,7 @@ extension DefaultQuestionCoordinator {
         questionDetailViewModel.navigateToBookDetail
             .withUnretained(self)
             .subscribe(onNext: { coordinator, book in
-                coordinator.showBookDetailScreen(book)
+                coordinator.showBookDetailScreen(with: book)
             }).disposed(by: disposeBag)
         questionDetailViewController.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(questionDetailViewController, animated: true)
@@ -86,8 +86,8 @@ extension DefaultQuestionCoordinator {
     /// 책 상세 화면 표시
     ///
     /// 책 상세 화면을 생성하고, ViewModel과 ViewController를 연결
-    private func showBookDetailScreen(_: Book) {
-        let bookDetailViewModel = BookDetailViewModel()
+    private func showBookDetailScreen(with book: Book) {
+        let bookDetailViewModel = BookDetailViewModel(bookDetail: book)
         let bookDetailViewController = BookDetailViewController(viewModel: bookDetailViewModel)
         bookDetailViewModel.navigateBackRelay
             .observe(on: MainScheduler.instance)

--- a/BookKitty/BookKitty/Source/Coordinator/QuestionCoordinator.swift
+++ b/BookKitty/BookKitty/Source/Coordinator/QuestionCoordinator.swift
@@ -87,7 +87,11 @@ extension DefaultQuestionCoordinator {
     ///
     /// 책 상세 화면을 생성하고, ViewModel과 ViewController를 연결
     private func showBookDetailScreen(with book: Book) {
-        let bookDetailViewModel = BookDetailViewModel(bookDetail: book)
+        let bookRepository = MockBookRepository()
+        let bookDetailViewModel = BookDetailViewModel(
+            bookDetail: book,
+            bookRepository: bookRepository
+        )
         let bookDetailViewController = BookDetailViewController(viewModel: bookDetailViewModel)
         bookDetailViewModel.navigateBackRelay
             .observe(on: MainScheduler.instance)

--- a/BookKitty/BookKitty/Source/Feature/BookDetail/View/BookDetailInfoView.swift
+++ b/BookKitty/BookKitty/Source/Feature/BookDetail/View/BookDetailInfoView.swift
@@ -80,13 +80,13 @@ final class BookDetailInfoView: UIStackView {
 
     // MARK: - Internal
 
-    func setupData(with model: TestBookModel) {
-        bookThumbnailImageView.setupImage(imageLink: model.imageLink)
-        titleLabel.text = model.title
-        authorLabel.text = model.author
-        pubDateLabel.text = model.pubdate
-        isbnLabel.text = "ISBN: \(model.isbn)"
-        priceLabel.text = "가격 \(model.price)"
+    func setupData(with bookDetail: Book) {
+        bookThumbnailImageView.setupImage(imageLink: bookDetail.thumbnailUrl?.absoluteString ?? "")
+        titleLabel.text = bookDetail.title
+        authorLabel.text = bookDetail.author
+        pubDateLabel.text = bookDetail.pubDate
+        isbnLabel.text = "ISBN: \(bookDetail.isbn)"
+        priceLabel.text = "가격 \(bookDetail.price)"
     }
 
     private func configureUI() {

--- a/BookKitty/BookKitty/Source/Feature/BookDetail/View/BookDetailViewController.swift
+++ b/BookKitty/BookKitty/Source/Feature/BookDetail/View/BookDetailViewController.swift
@@ -72,7 +72,7 @@ final class BookDetailViewController: BaseViewController {
 
         let output = viewModel.transform(input)
 
-        output.model
+        output.bookDetail
             .withUnretained(self)
             .observe(on: MainScheduler.instance)
             .bind(onNext: { owner, model in
@@ -196,5 +196,17 @@ final class BookDetailViewController: BaseViewController {
 
 @available(iOS 17.0, *)
 #Preview {
-    BookDetailViewController(viewModel: BookDetailViewModel())
+    BookDetailViewController(
+        viewModel: BookDetailViewModel(
+            bookDetail: Book(
+                isbn: "9788950963262",
+                title: "침묵의 기술",
+                author: "조제프 앙투안 투생 디누아르",
+                publisher: "아르테(arte)",
+                thumbnailUrl: URL(
+                    string: "https://shopping-phinf.pstatic.net/main_3249696/32496966995.20240321071044.jpg"
+                )
+            )
+        )
+    )
 }

--- a/BookKitty/BookKitty/Source/Feature/BookDetail/View/BookDetailViewController.swift
+++ b/BookKitty/BookKitty/Source/Feature/BookDetail/View/BookDetailViewController.swift
@@ -75,13 +75,13 @@ final class BookDetailViewController: BaseViewController {
         output.bookDetail
             .withUnretained(self)
             .observe(on: MainScheduler.instance)
-            .bind(onNext: { owner, model in
-                owner.introSection.setupData(with: model.description)
-                owner.infoSection.inforView.setupData(with: model)
-                owner.configureRightBarButton(with: model.isOwned)
+            .bind(onNext: { owner, bookDetail in
+                owner.introSection.setupData(with: bookDetail.description)
+                owner.infoSection.inforView.setupData(with: bookDetail)
+                owner.configureRightBarButton(with: bookDetail.isOwned)
 
-                let mode: ManageBookMode = model.isOwned ? .delete : .add
-                owner.popupView = ManageBookPopupView(bookTitle: model.title, mode: mode)
+                let mode: ManageBookMode = bookDetail.isOwned ? .delete : .add
+                owner.popupView = ManageBookPopupView(bookTitle: bookDetail.title, mode: mode)
             }).disposed(by: disposeBag)
     }
 
@@ -206,7 +206,8 @@ final class BookDetailViewController: BaseViewController {
                 thumbnailUrl: URL(
                     string: "https://shopping-phinf.pstatic.net/main_3249696/32496966995.20240321071044.jpg"
                 )
-            )
+            ),
+            bookRepository: MockBookRepository()
         )
     )
 }

--- a/BookKitty/BookKitty/Source/Feature/BookDetail/ViewModel/BookDetailViewModel.swift
+++ b/BookKitty/BookKitty/Source/Feature/BookDetail/ViewModel/BookDetailViewModel.swift
@@ -10,20 +10,6 @@ import RxCocoa
 import RxRelay
 import RxSwift
 
-struct TestBookModel: Hashable {
-    let isbn: String
-    let title: String
-    let author: String
-    let publisher: String
-    let price: String
-    let description: String
-    let bookInfoLink: String
-    let imageLink: String
-    let createdAt: Date
-    let pubdate: String
-    let isOwned: Bool
-}
-
 final class BookDetailViewModel: ViewModelType {
     // MARK: - Nested Types
 
@@ -36,57 +22,33 @@ final class BookDetailViewModel: ViewModelType {
     }
 
     struct Output {
-        let model: PublishRelay<TestBookModel>
+        let bookDetail: PublishRelay<Book>
     }
 
     // MARK: - Properties
 
     let disposeBag = DisposeBag()
-    let isbnRelay = ReplayRelay<String>.create(bufferSize: 1)
-    let modelRelay = ReplayRelay<TestBookModel>.create(bufferSize: 1) // TODO: TestBookModel -> Book
     let navigateBackRelay = PublishRelay<Void>()
+
+    private var bookDetail: Book
 
     // MARK: - Private
 
-    private let model = PublishRelay<TestBookModel>() // TODO: TestBookModel -> Book
+    private let bookDetailRelay = PublishRelay<Book>() // TODO: TestBookModel -> Book
 
-    private let textBookDtailModel = TestBookModel( // Test
-        isbn: "123412431234",
-        title: "Nudge",
-        author: "리처드 탈러, 캐스 선트타인",
-        publisher: "리더스북",
-        price: "20,000",
-        description:
-        """
-        “넛지 헬스케어”는 사람들이 무의식적으로 더 건강한 선택을 하도록 유도하는 넛지(Nudge) 이론을 기반으로 한 혁신적인 헬스케어 전략을 다룬 책입니다.
-        이 책은 단순히 운동과 식단 조절을 강조하는 기존의 건강 관리 방식에서 벗어나, 인간의 행동 심리를 활용하여 자연스럽고 지속 가능한 건강 습관을 형성하는 방법을 탐구합니다.
-        넛지 이론은 사람들이 강요나 제한 없이도 보다 나은 선택을 하도록 돕는 데 초점을 맞추고 있으며, 이를 통해 헬스케어 분야에서도 효과적인 변화를 이끌어낼 수 있음을 강조합니다.
-        저자는 다양한 연구 사례와 실험 결과를 바탕으로, 작은 변화가 우리의 건강 행동에 미치는 영향을 분석하며, 실생활에서 쉽게 적용할 수 있는 구체적인 실천 방안을 제시합니다.
-        또한, 개인뿐만 아니라 기업, 정부, 의료 기관 등 다양한 조직이 넛지 기법을 활용하여 건강 증진을 촉진할 수 있는 방법도 설명하며, 보다 넓은 사회적 차원에서 웰빙을 증진할 수 있는 가능성을 탐색합니다. 
-        이 책은 건강을 지키는 것이 어렵고 부담스러운 것이 아니라, 일상 속에서 자연스럽게 유도될 수 있다는 점을 강조하며, 보다 나은 삶을 위한 실용적인 통찰과 전략을 제공합니다.
-        """,
-        bookInfoLink: "",
-        imageLink: "https://shopping-phinf.pstatic.net/main_4718969/47189696637.20240421070849.jpg",
-        createdAt: Date(),
-        pubdate: "1999년 01월 01일 출판",
-        isOwned: true
-    )
+    // MARK: - Lifecycle
+
+    init(bookDetail: Book) {
+        self.bookDetail = bookDetail
+    }
 
     // MARK: - Functions
 
     func transform(_ input: Input) -> Output {
         input.viewDidLoad
-            .withLatestFrom(modelRelay)
-            .withUnretained(self) // Test
-            .map { owner, _ in owner.textBookDtailModel } // Test
-            .bind(to: model)
-            .disposed(by: disposeBag)
-
-        // Test
-        input.viewDidLoad
             .withUnretained(self)
-            .map { owner, _ in owner.textBookDtailModel }
-            .bind(to: model)
+            .map { owner, _ in owner.bookDetail }
+            .bind(to: bookDetailRelay)
             .disposed(by: disposeBag)
 
         input.leftBarButtonTapTrigger
@@ -97,6 +59,6 @@ final class BookDetailViewModel: ViewModelType {
             .bind(to: navigateBackRelay) // add, remove
             .disposed(by: disposeBag)
 
-        return Output(model: model)
+        return Output(bookDetail: bookDetailRelay)
     }
 }

--- a/BookKitty/BookKitty/Source/Repository/Mock/MockBookRepository.swift
+++ b/BookKitty/BookKitty/Source/Repository/Mock/MockBookRepository.swift
@@ -19,7 +19,8 @@ final class MockBookRepository: BookRepository {
             publisher: "아르테(arte)",
             thumbnailUrl: URL(
                 string: "https://shopping-phinf.pstatic.net/main_3249696/32496966995.20240321071044.jpg"
-            )
+            ),
+            isOwned: true
         ),
         Book(
             isbn: "9788954625760",
@@ -49,6 +50,8 @@ final class MockBookRepository: BookRepository {
             )
         ),
     ]
+
+    // MARK: - Functions
 
     /// 아래 함수는 실제로 레포지토리에서 구현되지 않았습니다.
     /// fetchBookList 함수를 사용해 주세요.
@@ -118,10 +121,12 @@ final class MockBookRepository: BookRepository {
     }
 
     func addBookToShelf(isbn _: String) -> Bool {
-        true
+        print("책 서재에 추가")
+        return true
     }
 
     func exceptBookFromShelf(isbn _: String) -> Bool {
-        true
+        print("책 서재에서 제거")
+        return true
     }
 }

--- a/BookKitty/BookKitty/Source/Repository/Mock/MockQuestionHistoryRepository.swift
+++ b/BookKitty/BookKitty/Source/Repository/Mock/MockQuestionHistoryRepository.swift
@@ -24,7 +24,8 @@ final class MockQuestionHistoryRepository: QuestionHistoryRepository {
                     publisher: "아르테(arte)",
                     thumbnailUrl: URL(
                         string: "https://shopping-phinf.pstatic.net/main_3249696/32496966995.20240321071044.jpg"
-                    )
+                    ),
+                    isOwned: true
                 ),
                 Book(
                     isbn: "9788954625760",


### PR DESCRIPTION
## ✅ 작업 사항
- Book을 넘겨받아 뷰컨에 데이터 제공하도록 구현
- ManageBookPopupView 아이콘 수정
- 팝업 버튼 탭 시 책 추가 / 삭제 로직 추가

## 👉 리뷰 포인트
### 소유를 판단하는 상태 고민
- Book 모델의 소유를 나타내는 상태를 Book 모델에 곧바로 접근해서 알아내는 방식이 괜찮을까?
- 별도의 모델을 두는 게 좋을까 고민
- 일단 앱 구조가 단순하기 때문에 굳이 분리하지 않고 지금 구조로 진행

## 📸 스크린샷

| 소유 -> 삭제 | 미소유 -> 추가 |
| -- | -- |
|<img src = "https://github.com/user-attachments/assets/66ef97de-34b5-49fe-95d0-f4c6d54f1126" width=300>|<img src="https://github.com/user-attachments/assets/7441112a-56ff-423b-ad7a-696862df4d3c" width=300>|


## 😀 기타
- 실제 Local 레포지토리 객체로 변환해야 합니다
- BookDetail 화면에서 바깥으로 navigation한 이후 reload 로직 추가가 필요합니다.
