### PR TITLE
[Feat] 책장 등록/삭제 여부 곧바로 반영되도록 구현

### DIFF
--- a/BookKitty/BookKitty/Source/Feature/Home/View/HomeViewController.swift
+++ b/BookKitty/BookKitty/Source/Feature/Home/View/HomeViewController.swift
@@ -127,6 +127,7 @@ class HomeViewController: BaseViewController {
     override func bind() {
         let input = HomeViewModel.Input(
             viewDidLoad: viewDidLoadRelay.asObservable(),
+            viewWillAppear: viewWillAppearRelay.asObservable(),
             bookSelected: bookSelectedRelay.asObservable()
         )
 

--- a/BookKitty/BookKitty/Source/Feature/Home/ViewModel/HomeViewModel.swift
+++ b/BookKitty/BookKitty/Source/Feature/Home/ViewModel/HomeViewModel.swift
@@ -9,6 +9,7 @@ final class HomeViewModel: ViewModelType {
 
     struct Input {
         let viewDidLoad: Observable<Void> // 뷰가 로드될 때 전달받은 질문
+        let viewWillAppear: Observable<Void> // 뷰가 나타날 때 소유 여부 새로고침
         let bookSelected: Observable<Book> // 사용자가 선택한 책
     }
 
@@ -49,6 +50,17 @@ final class HomeViewModel: ViewModelType {
                     limit: 5
                 )
 
+                return [SectionOfBook(items: fetchedBooks)]
+            }
+            .bind(to: recommendedBooksRelay)
+            .disposed(by: disposeBag)
+
+        // 홈 화면 돌아올 때마다 업데이트
+        // 비효율적일 수 있음 주의
+        input.viewWillAppear
+            .withUnretained(self)
+            .map { _, _ in
+                let fetchedBooks = self.bookRepository.fetchRecentRecommendedBooks()
                 return [SectionOfBook(items: fetchedBooks)]
             }
             .bind(to: recommendedBooksRelay)

--- a/BookKitty/BookKitty/Source/Feature/QuestionDetail/View/QuestionDetailViewController.swift
+++ b/BookKitty/BookKitty/Source/Feature/QuestionDetail/View/QuestionDetailViewController.swift
@@ -116,6 +116,7 @@ final class QuestionDetailViewController: BaseViewController {
     override func bind() {
         let input = QuestionDetailViewModel.Input(
             viewDidLoad: viewDidLoadRelay.asObservable(),
+            viewWillAppear: viewWillAppearRelay.asObservable(),
             deleteButtonTapped: navigationBar.rightButtonTapped.asObservable(),
             backButtonTapped: navigationBar.backButtonTapped.asObservable(),
             bookTapped: bookTappedRelay.asObservable()

--- a/BookKitty/BookKitty/Source/Feature/QuestionDetail/ViewModel/QuestionDetailViewModel.swift
+++ b/BookKitty/BookKitty/Source/Feature/QuestionDetail/ViewModel/QuestionDetailViewModel.swift
@@ -17,6 +17,7 @@ final class QuestionDetailViewModel: ViewModelType {
 
     struct Input {
         let viewDidLoad: Observable<Void>
+        let viewWillAppear: Observable<Void>
         let deleteButtonTapped: Observable<Void>
         let backButtonTapped: Observable<Void>
         let bookTapped: Observable<Book>
@@ -68,6 +69,21 @@ final class QuestionDetailViewModel: ViewModelType {
                 let sectionOfBooks = SectionOfBook(items: qna.recommendedBooks)
                 self.recommendedBooksRelay.accept([sectionOfBooks])
             })
+            .disposed(by: disposeBag)
+
+        input.viewWillAppear
+            .skip(1)
+            .withUnretained(self)
+            .map { owner, _ in
+                if let updatedQnA = owner.questionHistoryRepository
+                    .fetchQuestion(by: owner.questionAnswer.id) {
+                    let books = updatedQnA.recommendedBooks
+                    return [SectionOfBook(items: books)]
+                } else {
+                    return [SectionOfBook(items: owner.questionAnswer.recommendedBooks)]
+                }
+            }
+            .bind(to: recommendedBooksRelay)
             .disposed(by: disposeBag)
 
         input.deleteButtonTapped

--- a/BookKitty/BookKitty/Source/Feature/QuestionResult/View/QuestionResultViewController.swift
+++ b/BookKitty/BookKitty/Source/Feature/QuestionResult/View/QuestionResultViewController.swift
@@ -167,6 +167,7 @@ final class QuestionResultViewController: BaseViewController {
     override func bind() {
         let input = QuestionResultViewModel.Input(
             viewDidLoad: viewDidLoadRelay.asObservable(),
+            viewWillAppear: viewWillAppearRelay.asObservable(),
             bookSelected: bookSelectedRelay.asObservable(),
             submitButtonTapped: submitButtonTappedRelay.asObservable()
         )

--- a/BookKitty/BookKitty/Source/Repository/LocalQuestionHistoryRepository.swift
+++ b/BookKitty/BookKitty/Source/Repository/LocalQuestionHistoryRepository.swift
@@ -63,7 +63,7 @@ struct LocalQuestionHistoryRepository: QuestionHistoryRepository {
     func saveQuestionAnswer(data: QuestionAnswer) -> UUID? {
         let questionEntity = QuestionAnswerEntity(context: context)
 
-        questionEntity.id = UUID()
+        questionEntity.id = data.id
         questionEntity.aiAnswer = data.gptAnswer
         questionEntity.userQuestion = data.userQuestion
         questionEntity.createdAt = data.createdAt
@@ -103,6 +103,7 @@ struct LocalQuestionHistoryRepository: QuestionHistoryRepository {
             bookCoreDataManager.entityToModel(entity: $0)
         }
 
+        // TODO: Date, UUID가 새로 생기면 데이터가 달라집니다. id, createdAt이 존재하지 않을 경우 예외처리를 통해 개발자에게 알리는 작업을 추가하면 좋을 듯 합니다!
         return QuestionAnswer(
             createdAt: entity.createdAt ?? Date(),
             userQuestion: entity.userQuestion ?? "",


### PR DESCRIPTION
## ✅ 작업 사항
- 홈 뷰, 질문 결과 뷰, 질문 디테일 뷰에서 책 등록 / 삭제 여부 곧바로 반영되도록 구현

## 👉 리뷰 포인트
### 상태 일관성 vs 효율성
- 구현 방법으로 코어 데이터에서 최신화된 데이터 가져오기 / 뷰모델에서 상태 들고 있으며 사용자에게 보여지는 정보만 변경하기 두 가지가 떠올랐다.
- 상태를 일관되게 유지하는 방향이 로직을 간소화하고 유지보수에 좋은 영향을 미칠 것이라 생각해 viewWillAppear시 코어 데이터에서 최신 값을 가져오는 방식을 선택하였다.
- 다만 이 방법은 매번 Core Data와 통신한다. 성능에 영향을 미치지는 않는지 면밀한 테스트 필요

## 📸 스크린샷

| 예시 영상 |
| -- |
|<img src="https://github.com/user-attachments/assets/96715155-b880-4923-a51e-3e6a38b01ddc" width=300>|
