### PR TITLE
[Feat] 에러 알림 뷰컨 구현

### DIFF
--- a/BookKitty/BookKitty/Source/Common/Error/ErrorAlertController.swift
+++ b/BookKitty/BookKitty/Source/Common/Error/ErrorAlertController.swift
@@ -1,0 +1,79 @@
+//
+//  ErrorAlertController.swift
+//  BookKitty
+//
+//  Created by 권승용 on 2/13/25.
+//
+
+import DesignSystem
+import RxSwift
+import SnapKit
+import Then
+import UIKit
+
+final class ErrorAlertController: BaseViewController {
+    // MARK: - Properties
+
+    private let popup: FailAlertPopupView
+
+    // MARK: - Lifecycle
+
+    init(
+        errorTitle: String,
+        errorBody: String,
+        buttonTitle: String
+    ) {
+        popup = FailAlertPopupView(
+            primaryMessage: errorTitle,
+            secondaryMessage: errorBody,
+            buttonTitle: buttonTitle
+        )
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Overridden Functions
+
+    override func configureHierarchy() {
+        view.addSubview(popup)
+    }
+
+    override func configureLayout() {
+        popup.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.horizontalEdges.equalToSuperview().inset(Vars.spacing24)
+        }
+    }
+
+    override func configureBackground() {
+        view.backgroundColor = Colors.backgroundModal
+    }
+
+    override func bind() {
+        popup.confirmButton.rx.tap
+            .subscribe(onNext: { [weak self] in
+                self?.dismiss(animated: false)
+            })
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - Functions
+
+    func present(from parentVC: UIViewController) {
+        modalPresentationStyle = .overFullScreen
+        parentVC.present(self, animated: false)
+    }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    ErrorAlertController(
+        errorTitle: "some text",
+        errorBody: "secondary message",
+        buttonTitle: "button title"
+    )
+}


### PR DESCRIPTION
## ✅ 작업 사항
- 에러 및 알림을 나타내는 공통적인 뷰컨을 구현하였습니다.
- 어디서든 손쉽게 사용할 수 있도록 present 메소드를 구현하였습니다.

## 📸 스크린샷
| 동작 gif |
| -- |
|<img src="https://github.com/user-attachments/assets/324e8f4a-dd8d-4691-832f-2317593b9a96" width=300>|

## 😀 기타
### 사용 방법
팝업이 필요한 ViewController에서 아래 코드를 삽입해주면 됩니다.

```swift
ErrorAlertController(
    errorTitle: "", // 에러 제목
    errorBody: "", // 에러 내용
    buttonTitle: "" // 버튼 제목
).present(from: self) // 에러를 present할 ViewController (주로 self)
```
일반적으로는 아래와 같이 뷰모델의 error Output의 구독자에서 사용할 것으로 예상됩니다.

```swift
  output.error
        .withUnretained(self)
        .subscribe(onNext: { owner, error in
            print("Error occurred : \(error)")
            ErrorAlertController(
                errorTitle: error.title,
                errorBody: error.body,
                buttonTitle: error.buttonTitle
            ).present(from: owner)
        })
        .disposed(by: disposeBag)
```
