### PR TITLE
[Feat] 알림 처리에 사용될 에러 프로토콜 정의

### DIFF
--- a/BookKitty/BookKitty/Source/Common/Error/Component/ErrorAlertController.swift
+++ b/BookKitty/BookKitty/Source/Common/Error/Component/ErrorAlertController.swift
@@ -18,15 +18,11 @@ final class ErrorAlertController: BaseViewController {
 
     // MARK: - Lifecycle
 
-    init(
-        errorTitle: String,
-        errorBody: String,
-        buttonTitle: String
-    ) {
+    init(presentableError: AlertPresentableError) {
         popup = FailAlertPopupView(
-            primaryMessage: errorTitle,
-            secondaryMessage: errorBody,
-            buttonTitle: buttonTitle
+            primaryMessage: presentableError.title,
+            secondaryMessage: presentableError.body,
+            buttonTitle: presentableError.buttonTitle
         )
         super.init(nibName: nil, bundle: nil)
     }
@@ -71,9 +67,5 @@ final class ErrorAlertController: BaseViewController {
 
 @available(iOS 17.0, *)
 #Preview {
-    ErrorAlertController(
-        errorTitle: "some text",
-        errorBody: "secondary message",
-        buttonTitle: "button title"
-    )
+    ErrorAlertController(presentableError: NetworkError.networkUnstable)
 }

--- a/BookKitty/BookKitty/Source/Common/Error/DataError.swift
+++ b/BookKitty/BookKitty/Source/Common/Error/DataError.swift
@@ -1,0 +1,23 @@
+//
+//  DataError.swift
+//  BookKitty
+//
+//  Created by 권승용 on 2/13/25.
+//
+
+enum DataError: AlertPresentableError {
+    case decodingFailed
+
+    // MARK: - Computed Properties
+
+    var title: String { "데이터 에러" }
+
+    var body: String {
+        switch self {
+        case .decodingFailed:
+            return "디코딩 실패"
+        }
+    }
+
+    var buttonTitle: String { "확인" }
+}

--- a/BookKitty/BookKitty/Source/Common/Error/NetworkError.swift
+++ b/BookKitty/BookKitty/Source/Common/Error/NetworkError.swift
@@ -1,0 +1,25 @@
+//
+// NetworkError.swift
+//  BookKitty
+//
+//  Created by 권승용 on 2/13/25.
+//
+
+enum NetworkError: AlertPresentableError {
+    case networkUnstable
+
+    // MARK: - Computed Properties
+
+    var title: String { "네트워크 오류" }
+
+    var body: String {
+        switch self {
+        case .networkUnstable:
+            return "네트워크가 안정적이지 않습니다. 네트워크 환경을 확인해 주세요!"
+        }
+    }
+
+    var buttonTitle: String {
+        "확인"
+    }
+}

--- a/BookKitty/BookKitty/Source/Common/Error/Protocol/AlertPresentableError.swift
+++ b/BookKitty/BookKitty/Source/Common/Error/Protocol/AlertPresentableError.swift
@@ -1,0 +1,14 @@
+//
+//  AlertPresentableError.swift
+//  BookKitty
+//
+//  Created by 권승용 on 2/13/25.
+//
+
+import Foundation
+
+protocol AlertPresentableError: Error {
+    var title: String { get }
+    var body: String { get }
+    var buttonTitle: String { get }
+}


### PR DESCRIPTION
## ✅ 작업 사항
- AlertPresentableError 프로토콜 구현
- ErrorAlertController 인자 AlertPresentableError로 수정

## 👉 리뷰 포인트
### 공통 에러 타입 구현
```swift
protocol AlertPresentableError: Error {
    var title: String { get }
    var body: String { get }
    var buttonTitle: String { get }
}
```
위 프로토콜을 만들어 에러 알림에 필요한 값들을 가지는 타입의 요구사항을 나타냈습니다.

아래와 같이 사용할 수 있습니다.

```swift
enum NetworkError: AlertPresentableError {
    case networkUnstable

    // MARK: - Computed Properties

    var title: String { "네트워크 오류" }

    var body: String {
        switch self {
        case .networkUnstable:
            return "네트워크가 안정적이지 않습니다. 네트워크 환경을 확인해 주세요!"
        }
    }

    var buttonTitle: String {
        "확인"
    }
}
```

또한 ErrorAlertController의 생성자에 해당 프로토콜을 준수하는 타입만 넣도록 하여 사용성을 좋게 해 보았습니다.

```swift
init(presentableError: AlertPresentableError) {
    popup = FailAlertPopupView(
        primaryMessage: presentableError.title,
        secondaryMessage: presentableError.body,
        buttonTitle: presentableError.buttonTitle
    )
    super.init(nibName: nil, bundle: nil)
}
```
