### PR TITLE
[Fix] 최근책 목록에서 중복 책 제거

### DIFF
--- a/BookKitty/BookKitty/BookMatchKit/Sources/BookMatchService/Service/BookSearchService.swift
+++ b/BookKitty/BookKitty/BookMatchKit/Sources/BookMatchService/Service/BookSearchService.swift
@@ -2,7 +2,6 @@ import BookMatchAPI
 import BookMatchCore
 import RxSwift
 
-
 public final class BookSearchService: BookSearchable {
     // MARK: - Properties
 

--- a/BookKitty/BookKitty/Source/Feature/AddBook/View/AddBookViewController.swift
+++ b/BookKitty/BookKitty/Source/Feature/AddBook/View/AddBookViewController.swift
@@ -97,7 +97,7 @@ final class AddBookViewController: BaseViewController {
     // MARK: - Overridden Functions
 
     // MARK: - UI Setup
-    
+
     override func configureNavItem() {
         navigationBar.setupTitle(with: "새로운 책 추가하기")
     }

--- a/BookKitty/BookKitty/Source/Persistence/BookQALinkCoreDataManager.swift
+++ b/BookKitty/BookKitty/Source/Persistence/BookQALinkCoreDataManager.swift
@@ -18,7 +18,7 @@ final class BookQALinkCoreDataManager: BookQALinkCoreDataManageable {
             BookQuestionAnswerLinkEntity.fetchRequest()
 
         fetchRequest.sortDescriptors = [NSSortDescriptor(key: "createdAt", ascending: false)]
-        fetchRequest.fetchLimit = 5
+        fetchRequest.fetchLimit = 20
 
         do {
             let fetchresult = try context.fetch(fetchRequest)

--- a/BookKitty/BookKitty/Source/Repository/LocalBookRepository.swift
+++ b/BookKitty/BookKitty/Source/Repository/LocalBookRepository.swift
@@ -85,15 +85,24 @@ struct LocalBookRepository: BookRepository {
     /// 질문답변을 통해 최근에 추천받은 책의 목록을 가져옵니다.
     /// - Returns: Book 모델의 배열
     func fetchRecentRecommendedBooks() -> [Book] {
-        let linkEntities = bookQALinkCoreDataManager.selectRecentRecommendedBooks(context: context)
+        let linkEntities = bookQALinkCoreDataManager.selectRecentRecommendedBooks(
+            context:
+            context
+        )
         var books: [Book] = []
 
         for linkEntity in linkEntities {
             if let bookEntity = linkEntity.book,
                let book = bookCoreDataManager.entityToModel(entity: bookEntity) {
-                books.append(book)
+                if !books.contains(book) {
+                    books.append(book)
+                }
+            }
+            if books.count == 5 {
+                break
             }
         }
+
         BookKittyLogger.log("최근 추천된 책 불러오기 성공")
         return books
     }


### PR DESCRIPTION
## ✅ 작업 사항
- 홈 화면의 최근 책을 가져올 때 중복된 책을 가져오지 않도록 수정하였습니다.

## 👉 리뷰 포인트
- 포맷터가 코드 줄을 이상하게 바꿉니다...
- 최근 책을 20권 가져오고 순서대로 반환할 목록 변수에 넣다가 5개가 차면 고! 하는 형식.
- 코어데이터 자체 fetch 만으로는 원하는 결과만 쏙 빼오는 방법은 없네요.