### PR TITLE
[Fix] 책 중복 에러 잘 표시되도록 변경

### DIFF
--- a/BookKitty/BookKitty/Source/Feature/AddBook/ViewModel/AddBookViewModel.swift
+++ b/BookKitty/BookKitty/Source/Feature/AddBook/ViewModel/AddBookViewModel.swift
@@ -115,6 +115,7 @@ final class AddBookViewModel: ViewModelType {
                 if isSaved {
                     owner.navigateBackRelay.accept(())
                 } else {
+                    BookKittyLogger.log("중복된 책 에러 발생")
                     owner.errorRelay.accept(AddBookError.duplicatedBook)
                 }
             }, onError: { owner, error in

--- a/BookKitty/BookKitty/Source/Feature/AddBookByTitle/View/Popup/AddBookConfirmViewController.swift
+++ b/BookKitty/BookKitty/Source/Feature/AddBookByTitle/View/Popup/AddBookConfirmViewController.swift
@@ -50,15 +50,15 @@ final class AddBookConfirmViewController: BaseViewController {
     override func bind() {
         popup.cancelButton.rx.tap
             .subscribe(with: self, onNext: { owned, _ in
-                owned.completion(false)
                 owned.dismiss(animated: false)
+                owned.completion(false)
             })
             .disposed(by: disposeBag)
 
         popup.confirmButton.rx.tap
             .subscribe(with: self, onNext: { owned, _ in
-                owned.completion(true)
                 owned.dismiss(animated: false)
+                owned.completion(true)
             })
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## ✅ 작업 사항
- 책 중복 에러 잘 표시되도록 변경

## 👉 리뷰 포인트
### 문제 상황
- 추가 팝업(모달) -> 추가 확인 -> 중복된 책임을 감지 -> 에러 방출 -> 에러 팝업(모달) -> 추가 팝업 제거(dismiss)
- 위 흐름에서 추가 팝업 모달이 나타나 있는 상황에서 dismiss되기 이전에 에러 팝업 모달의 present가 수행되었기 때문에 에러 팝업 모달이 제대로 안 나타나는 문제가 있었습니다.
- dismiss를 먼저 수행하도록 변경해 문제를 해결했습니다.