### PR TITLE
[Fix] QnA 히스토리 헤더 스크롤에서 분리

### DIFF
--- a/BookKitty/BookKitty/Source/Feature/QuestionHistory/View/QuestionHistoryViewController.swift
+++ b/BookKitty/BookKitty/Source/Feature/QuestionHistory/View/QuestionHistoryViewController.swift
@@ -94,30 +94,21 @@ final class QuestionHistoryViewController: BaseViewController {
     }
 
     override func configureHierarchy() {
-        view.addSubview(questionTableView)
-
-        // titleLabel을 포함할 containerView 생성
-        let headerView = UIView(frame: CGRect(
-            x: 0,
-            y: 0,
-            width: view.bounds.width,
-            height: 42 + Vars.paddingReg
-        ))
-        headerView.addSubview(titleLabel)
-
-        // titleLabel 제약조건 설정
-        titleLabel.snp.makeConstraints { make in
-            make.horizontalEdges.equalToSuperview()
-            make.bottom.equalToSuperview().inset(Vars.paddingSmall)
-        }
-
-        questionTableView.tableHeaderView = headerView
+        [
+            titleLabel,
+            questionTableView,
+        ].forEach { view.addSubview($0) }
     }
 
     override func configureLayout() {
+        titleLabel.snp.makeConstraints { make in
+            make.top.leading.equalTo(view.safeAreaLayoutGuide).offset(Vars.spacing20)
+        }
+
         questionTableView.snp.makeConstraints { make in
-            make.verticalEdges.equalTo(view.safeAreaLayoutGuide)
+            make.top.equalTo(titleLabel.snp.bottom).offset(Vars.spacing24)
             make.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(Vars.paddingSmall)
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
         }
     }
 }


### PR DESCRIPTION
## ✅ 작업 사항
- QnA 히스토리 헤더를 스크롤에서 분리해 내 서재와 일관적인 디자인을 갖도록 하였습니다.

## 📸 스크린샷
| 결과 스크린샷 |
| -- |
|<img src="https://github.com/user-attachments/assets/6be7d570-38ad-45bd-a7e4-34d44c58d39e" width=300>|
